### PR TITLE
Fix for when `value` is a 2-character string

### DIFF
--- a/alfred.py
+++ b/alfred.py
@@ -45,9 +45,9 @@ class Item(object):
             value = getattr(self, attribute)
             if value is None:
                 continue
-            try:
+            if len(value) == 2 and isinstance(value[1], dict):
                 (value, attributes) = value
-            except:
+            else:
                 attributes = {}
             SubElement(item, attribute, self.unicode(attributes)).text = unicode(value)
         return item


### PR DESCRIPTION
`(value, attributes) = value` also succeeds when `value` is a
2-character string, not only a 2-item tuple/list.

Now it explicitly checks for a dictionary, so attributes doesn't end up a string.
