### PR TITLE
Use unicode instead of str to encode Item values when converting to xml

### DIFF
--- a/alfred.py
+++ b/alfred.py
@@ -26,9 +26,9 @@ class Item(object):
         try:
             items = iter(value.items())
         except AttributeError:
-            return str(value)
+            return unicode(value)
         else:
-            return dict(map(str, item) for item in items)
+            return dict(map(unicode, item) for item in items)
 
     def __init__(self, attributes, title, subtitle, icon=None):
         self.attributes = attributes
@@ -49,7 +49,7 @@ class Item(object):
                 (value, attributes) = value
             else:
                 attributes = {}
-            SubElement(item, attribute, self.unicode(attributes)).text = str(value)
+            SubElement(item, attribute, self.unicode(attributes)).text = self.unicode(value)
         return item
 
 def args(characters=None):

--- a/test.py
+++ b/test.py
@@ -44,6 +44,13 @@ class AlfredTests(unittest.TestCase):
         alfred_filename = alfred.decode(self._test_filename)
         self.assert_(alfred_filename == fs_filename)
 
+    def test_unicode_value_xml(self):
+        """Ensure we can handle converting Items with unicode values to xml"""
+        item = alfred.Item({}, u'\xb7', u'\xb7')
+        expected = '<items><item><title>\xc2\xb7</title><subtitle>\xc2\xb7</subtitle></item></items>'
+        actual = alfred.xml([item])
+        self.assert_(expected == actual, '{!r} != {!r}'.format(expected, actual))
+
 
 if __name__ == u'__main__':
     unittest.main()


### PR DESCRIPTION
I was consistently getting an encoding error when trying to put unicode strings in `alfred.Item`.

I included a test that fails with the current version of alfred-python but passes in this branch. Hopefully I didn't break anything else that was relying on `str` in `alfred.Item.unicode`, but please let me know if I did and I'll work to fix it.
